### PR TITLE
ZXing project links update

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ INSTALL
 ========
 1. Add ZXing QRCode libraries<br/>
 Put the jars files on `lib` folder on your CFML Engine `CLASSPATH`
-   * Coldfusion : &lt;CFPATH&gt;/runtime/lib <br/>
+   * Coldfusion : &lt;CFPATH&gt;/runtime/lib
    * Railo: &lt;CFProject&gt;/WEB-INF/railo/lib
    * Lucee: &lt;CFProject&gt;/WEB-INF/lib
 2. Add the CFC set to your project

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ INSTALL
 ========
 1. Add ZXing QRCode libraries<br/>
 Put the jars files on `lib` folder on your CFML Engine `CLASSPATH`
-   * Coldfusion : &lt;CFPATH&gt;/runtime/lib
-   * Railo: &lt;CFProject&gt;/WEB-INF/railo/lib
-   * Lucee: &lt;CFProject&gt;/WEB-INF/lib
+   * Coldfusion : &lt;CFPATH&gt;`/runtime/lib`
+   * Railo: &lt;CFProject&gt;`/WEB-INF/railo/lib`
+   * Lucee: &lt;CFProject&gt;`/WEB-INF/lib`
 2. Add the CFC set to your project
 3. Play with it !
 

--- a/README.md
+++ b/README.md
@@ -12,13 +12,12 @@ Put the jars files on `lib` folder on your CFML Engine `CLASSPATH`
 2. Add the CFC set to your project
 3. Play with it !
 
-Sample:
-<code>
-&lt;cfset qrCode = new info.jlepage.QRCode() /&gt;<br/>
-&lt;cfset qrCode.setData('Hello World !') /&gt;<br/>
-&lt;cfset qrCode.writeToFile('myQRCode.png') /&gt;<br/>
-</code>
-
+CFML Sample :
+```
+<cfset qrCode = new info.jlepage.QRCode() />
+<cfset qrCode.setData("Hello World!") />
+<cfset qrCode.writeToFile("myQRCode.png") />
+```
 Can be more easy ? :)
 
 More samples on index.cfm

--- a/README.md
+++ b/README.md
@@ -4,13 +4,18 @@ Coldfusion CFML QR-Code Generator - Write QRCode to a file with less effort
 
 INSTALL
 ========
-1. Add ZXing QRCode libraries<br/>
-Put the jars files on `lib` folder on your CFML Engine `CLASSPATH`
-   * Coldfusion : &lt;CFPATH&gt;`/runtime/lib`
+1. Add ZXing QRCode libraries:
+   * `lib/zxing-3.5.0-core.jar`
+   * `lib/zxing-3.5.0-javase.jar`
+2. Put JAR files in `lib` folder on your CFML Engine `CLASSPATH`
+   * Coldfusion: &lt;CFPATH&gt;`/runtime/lib`
    * Railo: &lt;CFProject&gt;`/WEB-INF/railo/lib`
    * Lucee: &lt;CFProject&gt;`/WEB-INF/lib`
-2. Add the CFC set to your project
-3. Play with it !
+3. Add the CFC set to your project
+   * `src/info/jlepage/Barcode.cfc`
+   * `src/info/jlepage/QRCode.cfc`
+   * `src/info/jlepage/ZXing.cfc`
+4. Play with it!
 
 CFML Sample :
 ```

--- a/README.md
+++ b/README.md
@@ -4,15 +4,13 @@ Coldfusion CFML QR-Code Generator - Write QRCode to a file with less effort
 
 INSTALL
 ========
-1 - Add ZXing QRCode libraries<br/>
-Put the jars files on lib folder on your CFML Engine classpath
-
-Coldfusion : &lt;CFPATH&gt;/runtime/lib<br/>
-Railo: &lt;CFProject&gt;/WEB-INF/railo/lib
-
-2 - Add the CFC to your project
-
-3 - Play with it !
+1. Add ZXing QRCode libraries<br/>
+Put the jars files on `lib` folder on your CFML Engine `CLASSPATH`
+   * Coldfusion : &lt;CFPATH&gt;/runtime/lib <br/>
+   * Railo: &lt;CFProject&gt;/WEB-INF/railo/lib
+   * Lucee: &lt;CFProject&gt;/WEB-INF/lib
+2. Add the CFC set to your project
+3. Play with it !
 
 Sample:
 <code>

--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ INSTALL
    * `src/info/jlepage/ZXing.cfc`
 4. Play with it!
 
-CFML Sample :
+CFML Sample:
 ```
 <cfset qrCode = new info.jlepage.QRCode() />
 <cfset qrCode.setData("Hello World!") />
 <cfset qrCode.writeToFile("myQRCode.png") />
 ```
-CFScript Sample :
+CFScript Sample:
 ```
 <cfscript>
 qrCode = new info.jlepage.QRCode();
@@ -31,7 +31,7 @@ qrCode.setData("Hello World!");
 qrCode.writeToFile("myQRCode.png");
 </cfscript>
 ```
-Can be more easy ? :)
+Can be more easy? :)
 
 More samples on index.cfm
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ ZXING
 ========
 
 Please visite the ZXing project at : <br/>
-http://code.google.com/p/zxing/
+https://github.com/zxing/zxing
 
 ZXING is under Apache License 2.0 <br/>
 http://www.apache.org/licenses/LICENSE-2.0

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ https://github.com/zxing/zxing
 
 ZXING is under Apache License 2.0 <br/>
 http://www.apache.org/licenses/LICENSE-2.0
+https://github.com/zxing/zxing/blob/master/LICENSE
 
 
 LICENCE

--- a/README.md
+++ b/README.md
@@ -1,23 +1,20 @@
 CFQRCode
 ========
-
 Coldfusion CFML QR-Code Generator - Write QRCode to a file with less effort
 
 INSTALL
 ========
-
-1 - Add ZXing QRCode libraries <br/>
+1 - Add ZXing QRCode libraries<br/>
 Put the jars files on lib folder on your CFML Engine classpath
 
-Coldfusion : &lt;CFPATH&gt;/runtime/lib <br/>
+Coldfusion : &lt;CFPATH&gt;/runtime/lib<br/>
 Railo: &lt;CFProject&gt;/WEB-INF/railo/lib
 
 2 - Add the CFC to your project
 
 3 - Play with it !
 
-Sample :
-
+Sample:
 <code>
 &lt;cfset qrCode = new info.jlepage.QRCode() /&gt;<br/>
 &lt;cfset qrCode.setData('Hello World !') /&gt;<br/>
@@ -28,24 +25,20 @@ Can be more easy ? :)
 
 More samples on index.cfm
 
-
 ZXING
 ========
-
-Please visite the ZXing project at : <br/>
+Please visite the ZXing project at:<br/>
 https://github.com/zxing/zxing
 
-ZXING is under Apache License 2.0 <br/>
+ZXING is under Apache License 2.0<br/>
 http://www.apache.org/licenses/LICENSE-2.0<br/>
 https://github.com/zxing/zxing/blob/master/LICENSE
 
-
 LICENCE
 ========
-
 Copyright (c) 2013, Jerome Lepage http://www.jlepage.info
 
-This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 Unported License <br/>
+This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 Unported License<br/>
 http://creativecommons.org/licenses/by-sa/3.0/
 
 Unless required by applicable law or agreed to in writing, software

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Please visite the ZXing project at : <br/>
 https://github.com/zxing/zxing
 
 ZXING is under Apache License 2.0 <br/>
-http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0<br/>
 https://github.com/zxing/zxing/blob/master/LICENSE
 
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ qrCode.setData("Hello World!");
 qrCode.writeToFile("myQRCode.png");
 </cfscript>
 ```
-Can be more easy? :)
+Can be more easy? :smiley:
 
 More samples on index.cfm
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,14 @@ CFML Sample :
 <cfset qrCode.setData("Hello World!") />
 <cfset qrCode.writeToFile("myQRCode.png") />
 ```
+CFScript Sample :
+```
+<cfscript>
+qrCode = new info.jlepage.QRCode();
+qrCode.setData("Hello World!");
+qrCode.writeToFile("myQRCode.png");
+</cfscript>
+```
 Can be more easy ? :)
 
 More samples on index.cfm

--- a/README.md
+++ b/README.md
@@ -31,9 +31,19 @@ qrCode.setData("Hello World!");
 qrCode.writeToFile("myQRCode.png");
 </cfscript>
 ```
+CFScript direct image binary:
+```
+<cfscript>
+qrCode = new info.jlepage.QRCode();
+qrCode.setData("Hello World!");
+imageBinary = qrCode.readBinary();
+</cfscript>
+```
 Can be more easy? :smiley:
 
-More samples on index.cfm
+More samples in:
+* `src/index.cfm`
+* `src/barcode.cfm`
 
 ZXING
 ========


### PR DESCRIPTION
Change summary:

1. ZXing project moved from Google Code to GitHub; update project link
2. Add ZXing LICENSE page link on separate line after Apache license link.

Thank you for your consideration.